### PR TITLE
Fix "View all versions" links

### DIFF
--- a/0.4.4/2016/02/09/blog-launched-new-responsive-columns-new-helpers/index.html
+++ b/0.4.4/2016/02/09/blog-launched-new-responsive-columns-new-helpers/index.html
@@ -115,7 +115,7 @@
               <p class="has-text-info is-size-6-desktop"><strong>0.4.4</strong></p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.4.4/2016/04/11/metro-ui-css-grid-with-bulma-tiles/index.html
+++ b/0.4.4/2016/04/11/metro-ui-css-grid-with-bulma-tiles/index.html
@@ -115,7 +115,7 @@
               <p class="has-text-info is-size-6-desktop"><strong>0.4.4</strong></p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.4.4/2017/03/10/new-field-element/index.html
+++ b/0.4.4/2017/03/10/new-field-element/index.html
@@ -115,7 +115,7 @@
               <p class="has-text-info is-size-6-desktop"><strong>0.4.4</strong></p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.4.4/blog/index.html
+++ b/0.4.4/blog/index.html
@@ -115,7 +115,7 @@
               <p class="has-text-info is-size-6-desktop"><strong>0.4.4</strong></p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.4.4/documentation/components/breadcrumb/index.html
+++ b/0.4.4/documentation/components/breadcrumb/index.html
@@ -115,7 +115,7 @@
               <p class="has-text-info is-size-6-desktop"><strong>0.4.4</strong></p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.4.4/documentation/components/card/index.html
+++ b/0.4.4/documentation/components/card/index.html
@@ -115,7 +115,7 @@
               <p class="has-text-info is-size-6-desktop"><strong>0.4.4</strong></p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.4.4/documentation/components/dropdown/index.html
+++ b/0.4.4/documentation/components/dropdown/index.html
@@ -115,7 +115,7 @@
               <p class="has-text-info is-size-6-desktop"><strong>0.4.4</strong></p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.4.4/documentation/components/level/index.html
+++ b/0.4.4/documentation/components/level/index.html
@@ -115,7 +115,7 @@
               <p class="has-text-info is-size-6-desktop"><strong>0.4.4</strong></p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.4.4/documentation/components/media-object/index.html
+++ b/0.4.4/documentation/components/media-object/index.html
@@ -115,7 +115,7 @@
               <p class="has-text-info is-size-6-desktop"><strong>0.4.4</strong></p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.4.4/documentation/components/menu/index.html
+++ b/0.4.4/documentation/components/menu/index.html
@@ -115,7 +115,7 @@
               <p class="has-text-info is-size-6-desktop"><strong>0.4.4</strong></p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.4.4/documentation/components/message/index.html
+++ b/0.4.4/documentation/components/message/index.html
@@ -115,7 +115,7 @@
               <p class="has-text-info is-size-6-desktop"><strong>0.4.4</strong></p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.4.4/documentation/components/modal/index.html
+++ b/0.4.4/documentation/components/modal/index.html
@@ -115,7 +115,7 @@
               <p class="has-text-info is-size-6-desktop"><strong>0.4.4</strong></p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.4.4/documentation/components/nav/index.html
+++ b/0.4.4/documentation/components/nav/index.html
@@ -115,7 +115,7 @@
               <p class="has-text-info is-size-6-desktop"><strong>0.4.4</strong></p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.4.4/documentation/components/navbar/index.html
+++ b/0.4.4/documentation/components/navbar/index.html
@@ -115,7 +115,7 @@
               <p class="has-text-info is-size-6-desktop"><strong>0.4.4</strong></p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>
@@ -591,7 +591,7 @@
               <p class="has-text-info is-size-6-desktop"><strong>0.4.4</strong></p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>
@@ -1331,7 +1331,7 @@
               <p class="has-text-info is-size-6-desktop"><strong>0.4.4</strong></p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.4.4/documentation/components/pagination/index.html
+++ b/0.4.4/documentation/components/pagination/index.html
@@ -115,7 +115,7 @@
               <p class="has-text-info is-size-6-desktop"><strong>0.4.4</strong></p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.4.4/documentation/components/panel/index.html
+++ b/0.4.4/documentation/components/panel/index.html
@@ -115,7 +115,7 @@
               <p class="has-text-info is-size-6-desktop"><strong>0.4.4</strong></p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.4.4/documentation/components/tabs/index.html
+++ b/0.4.4/documentation/components/tabs/index.html
@@ -115,7 +115,7 @@
               <p class="has-text-info is-size-6-desktop"><strong>0.4.4</strong></p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.4.4/documentation/elements/box/index.html
+++ b/0.4.4/documentation/elements/box/index.html
@@ -115,7 +115,7 @@
               <p class="has-text-info is-size-6-desktop"><strong>0.4.4</strong></p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.4.4/documentation/elements/button/index.html
+++ b/0.4.4/documentation/elements/button/index.html
@@ -115,7 +115,7 @@
               <p class="has-text-info is-size-6-desktop"><strong>0.4.4</strong></p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.4.4/documentation/elements/content/index.html
+++ b/0.4.4/documentation/elements/content/index.html
@@ -115,7 +115,7 @@
               <p class="has-text-info is-size-6-desktop"><strong>0.4.4</strong></p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.4.4/documentation/elements/delete/index.html
+++ b/0.4.4/documentation/elements/delete/index.html
@@ -115,7 +115,7 @@
               <p class="has-text-info is-size-6-desktop"><strong>0.4.4</strong></p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.4.4/documentation/elements/form/index.html
+++ b/0.4.4/documentation/elements/form/index.html
@@ -115,7 +115,7 @@
               <p class="has-text-info is-size-6-desktop"><strong>0.4.4</strong></p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.4.4/documentation/elements/icon/index.html
+++ b/0.4.4/documentation/elements/icon/index.html
@@ -115,7 +115,7 @@
               <p class="has-text-info is-size-6-desktop"><strong>0.4.4</strong></p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.4.4/documentation/elements/image/index.html
+++ b/0.4.4/documentation/elements/image/index.html
@@ -115,7 +115,7 @@
               <p class="has-text-info is-size-6-desktop"><strong>0.4.4</strong></p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.4.4/documentation/elements/notification/index.html
+++ b/0.4.4/documentation/elements/notification/index.html
@@ -115,7 +115,7 @@
               <p class="has-text-info is-size-6-desktop"><strong>0.4.4</strong></p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.4.4/documentation/elements/progress/index.html
+++ b/0.4.4/documentation/elements/progress/index.html
@@ -115,7 +115,7 @@
               <p class="has-text-info is-size-6-desktop"><strong>0.4.4</strong></p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.4.4/documentation/elements/table/index.html
+++ b/0.4.4/documentation/elements/table/index.html
@@ -115,7 +115,7 @@
               <p class="has-text-info is-size-6-desktop"><strong>0.4.4</strong></p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.4.4/documentation/elements/tag/index.html
+++ b/0.4.4/documentation/elements/tag/index.html
@@ -115,7 +115,7 @@
               <p class="has-text-info is-size-6-desktop"><strong>0.4.4</strong></p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.4.4/documentation/elements/title/index.html
+++ b/0.4.4/documentation/elements/title/index.html
@@ -115,7 +115,7 @@
               <p class="has-text-info is-size-6-desktop"><strong>0.4.4</strong></p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.4.4/documentation/form/checkbox/index.html
+++ b/0.4.4/documentation/form/checkbox/index.html
@@ -115,7 +115,7 @@
               <p class="has-text-info is-size-6-desktop"><strong>0.4.4</strong></p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.4.4/documentation/form/general/index.html
+++ b/0.4.4/documentation/form/general/index.html
@@ -115,7 +115,7 @@
               <p class="has-text-info is-size-6-desktop"><strong>0.4.4</strong></p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.4.4/documentation/form/input/index.html
+++ b/0.4.4/documentation/form/input/index.html
@@ -115,7 +115,7 @@
               <p class="has-text-info is-size-6-desktop"><strong>0.4.4</strong></p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.4.4/documentation/form/radio/index.html
+++ b/0.4.4/documentation/form/radio/index.html
@@ -115,7 +115,7 @@
               <p class="has-text-info is-size-6-desktop"><strong>0.4.4</strong></p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.4.4/documentation/form/select/index.html
+++ b/0.4.4/documentation/form/select/index.html
@@ -115,7 +115,7 @@
               <p class="has-text-info is-size-6-desktop"><strong>0.4.4</strong></p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.4.4/documentation/form/textarea/index.html
+++ b/0.4.4/documentation/form/textarea/index.html
@@ -115,7 +115,7 @@
               <p class="has-text-info is-size-6-desktop"><strong>0.4.4</strong></p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.4.4/documentation/grid/columns/index.html
+++ b/0.4.4/documentation/grid/columns/index.html
@@ -115,7 +115,7 @@
               <p class="has-text-info is-size-6-desktop"><strong>0.4.4</strong></p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.4.4/documentation/grid/tiles/index.html
+++ b/0.4.4/documentation/grid/tiles/index.html
@@ -115,7 +115,7 @@
               <p class="has-text-info is-size-6-desktop"><strong>0.4.4</strong></p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.4.4/documentation/layout/container/index.html
+++ b/0.4.4/documentation/layout/container/index.html
@@ -115,7 +115,7 @@
               <p class="has-text-info is-size-6-desktop"><strong>0.4.4</strong></p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.4.4/documentation/layout/footer/index.html
+++ b/0.4.4/documentation/layout/footer/index.html
@@ -115,7 +115,7 @@
               <p class="has-text-info is-size-6-desktop"><strong>0.4.4</strong></p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.4.4/documentation/layout/hero/index.html
+++ b/0.4.4/documentation/layout/hero/index.html
@@ -115,7 +115,7 @@
               <p class="has-text-info is-size-6-desktop"><strong>0.4.4</strong></p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.4.4/documentation/layout/section/index.html
+++ b/0.4.4/documentation/layout/section/index.html
@@ -115,7 +115,7 @@
               <p class="has-text-info is-size-6-desktop"><strong>0.4.4</strong></p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.4.4/documentation/modifiers/helpers/index.html
+++ b/0.4.4/documentation/modifiers/helpers/index.html
@@ -115,7 +115,7 @@
               <p class="has-text-info is-size-6-desktop"><strong>0.4.4</strong></p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.4.4/documentation/modifiers/responsive-helpers/index.html
+++ b/0.4.4/documentation/modifiers/responsive-helpers/index.html
@@ -115,7 +115,7 @@
               <p class="has-text-info is-size-6-desktop"><strong>0.4.4</strong></p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.4.4/documentation/modifiers/syntax/index.html
+++ b/0.4.4/documentation/modifiers/syntax/index.html
@@ -115,7 +115,7 @@
               <p class="has-text-info is-size-6-desktop"><strong>0.4.4</strong></p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.4.4/documentation/overview/classes/index.html
+++ b/0.4.4/documentation/overview/classes/index.html
@@ -115,7 +115,7 @@
               <p class="has-text-info is-size-6-desktop"><strong>0.4.4</strong></p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.4.4/documentation/overview/customize/index.html
+++ b/0.4.4/documentation/overview/customize/index.html
@@ -115,7 +115,7 @@
               <p class="has-text-info is-size-6-desktop"><strong>0.4.4</strong></p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.4.4/documentation/overview/functions/index.html
+++ b/0.4.4/documentation/overview/functions/index.html
@@ -115,7 +115,7 @@
               <p class="has-text-info is-size-6-desktop"><strong>0.4.4</strong></p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.4.4/documentation/overview/mixins/index.html
+++ b/0.4.4/documentation/overview/mixins/index.html
@@ -115,7 +115,7 @@
               <p class="has-text-info is-size-6-desktop"><strong>0.4.4</strong></p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.4.4/documentation/overview/modular/index.html
+++ b/0.4.4/documentation/overview/modular/index.html
@@ -115,7 +115,7 @@
               <p class="has-text-info is-size-6-desktop"><strong>0.4.4</strong></p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.4.4/documentation/overview/responsiveness/index.html
+++ b/0.4.4/documentation/overview/responsiveness/index.html
@@ -115,7 +115,7 @@
               <p class="has-text-info is-size-6-desktop"><strong>0.4.4</strong></p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.4.4/documentation/overview/start/index.html
+++ b/0.4.4/documentation/overview/start/index.html
@@ -115,7 +115,7 @@
               <p class="has-text-info is-size-6-desktop"><strong>0.4.4</strong></p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.4.4/documentation/overview/variables/index.html
+++ b/0.4.4/documentation/overview/variables/index.html
@@ -115,7 +115,7 @@
               <p class="has-text-info is-size-6-desktop"><strong>0.4.4</strong></p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.4.4/extensions/index.html
+++ b/0.4.4/extensions/index.html
@@ -115,7 +115,7 @@
               <p class="has-text-info is-size-6-desktop"><strong>0.4.4</strong></p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.4.4/index.html
+++ b/0.4.4/index.html
@@ -115,7 +115,7 @@
               <p class="has-text-info is-size-6-desktop"><strong>0.4.4</strong></p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.0/2016/02/09/blog-launched-new-responsive-columns-new-helpers/index.html
+++ b/0.5.0/2016/02/09/blog-launched-new-responsive-columns-new-helpers/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.0/2016/04/11/metro-ui-css-grid-with-bulma-tiles/index.html
+++ b/0.5.0/2016/04/11/metro-ui-css-grid-with-bulma-tiles/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.0/2017/03/10/new-field-element/index.html
+++ b/0.5.0/2017/03/10/new-field-element/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.0/2017/07/24/access-previous-bulma-versions/index.html
+++ b/0.5.0/2017/07/24/access-previous-bulma-versions/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.0/blog/index.html
+++ b/0.5.0/blog/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.0/documentation/components/breadcrumb/index.html
+++ b/0.5.0/documentation/components/breadcrumb/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.0/documentation/components/card/index.html
+++ b/0.5.0/documentation/components/card/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.0/documentation/components/dropdown/index.html
+++ b/0.5.0/documentation/components/dropdown/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.0/documentation/components/level/index.html
+++ b/0.5.0/documentation/components/level/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.0/documentation/components/media-object/index.html
+++ b/0.5.0/documentation/components/media-object/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.0/documentation/components/menu/index.html
+++ b/0.5.0/documentation/components/menu/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.0/documentation/components/message/index.html
+++ b/0.5.0/documentation/components/message/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.0/documentation/components/modal/index.html
+++ b/0.5.0/documentation/components/modal/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.0/documentation/components/nav/index.html
+++ b/0.5.0/documentation/components/nav/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.0/documentation/components/navbar/index.html
+++ b/0.5.0/documentation/components/navbar/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>
@@ -632,7 +632,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>
@@ -1376,7 +1376,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.0/documentation/components/pagination/index.html
+++ b/0.5.0/documentation/components/pagination/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.0/documentation/components/panel/index.html
+++ b/0.5.0/documentation/components/panel/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.0/documentation/components/tabs/index.html
+++ b/0.5.0/documentation/components/tabs/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.0/documentation/elements/box/index.html
+++ b/0.5.0/documentation/elements/box/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.0/documentation/elements/button/index.html
+++ b/0.5.0/documentation/elements/button/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.0/documentation/elements/content/index.html
+++ b/0.5.0/documentation/elements/content/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.0/documentation/elements/delete/index.html
+++ b/0.5.0/documentation/elements/delete/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.0/documentation/elements/form/index.html
+++ b/0.5.0/documentation/elements/form/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.0/documentation/elements/icon/index.html
+++ b/0.5.0/documentation/elements/icon/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.0/documentation/elements/image/index.html
+++ b/0.5.0/documentation/elements/image/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.0/documentation/elements/notification/index.html
+++ b/0.5.0/documentation/elements/notification/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.0/documentation/elements/progress/index.html
+++ b/0.5.0/documentation/elements/progress/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.0/documentation/elements/table/index.html
+++ b/0.5.0/documentation/elements/table/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.0/documentation/elements/tag/index.html
+++ b/0.5.0/documentation/elements/tag/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.0/documentation/elements/title/index.html
+++ b/0.5.0/documentation/elements/title/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.0/documentation/form/checkbox/index.html
+++ b/0.5.0/documentation/form/checkbox/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.0/documentation/form/general/index.html
+++ b/0.5.0/documentation/form/general/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.0/documentation/form/input/index.html
+++ b/0.5.0/documentation/form/input/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.0/documentation/form/radio/index.html
+++ b/0.5.0/documentation/form/radio/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.0/documentation/form/select/index.html
+++ b/0.5.0/documentation/form/select/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.0/documentation/form/textarea/index.html
+++ b/0.5.0/documentation/form/textarea/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.0/documentation/grid/columns/index.html
+++ b/0.5.0/documentation/grid/columns/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.0/documentation/grid/tiles/index.html
+++ b/0.5.0/documentation/grid/tiles/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.0/documentation/layout/container/index.html
+++ b/0.5.0/documentation/layout/container/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.0/documentation/layout/footer/index.html
+++ b/0.5.0/documentation/layout/footer/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.0/documentation/layout/hero/index.html
+++ b/0.5.0/documentation/layout/hero/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.0/documentation/layout/section/index.html
+++ b/0.5.0/documentation/layout/section/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.0/documentation/modifiers/helpers/index.html
+++ b/0.5.0/documentation/modifiers/helpers/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.0/documentation/modifiers/responsive-helpers/index.html
+++ b/0.5.0/documentation/modifiers/responsive-helpers/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.0/documentation/modifiers/syntax/index.html
+++ b/0.5.0/documentation/modifiers/syntax/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.0/documentation/modifiers/typography-helpers/index.html
+++ b/0.5.0/documentation/modifiers/typography-helpers/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.0/documentation/overview/classes/index.html
+++ b/0.5.0/documentation/overview/classes/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.0/documentation/overview/colors/index.html
+++ b/0.5.0/documentation/overview/colors/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.0/documentation/overview/customize/index.html
+++ b/0.5.0/documentation/overview/customize/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.0/documentation/overview/functions/index.html
+++ b/0.5.0/documentation/overview/functions/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.0/documentation/overview/mixins/index.html
+++ b/0.5.0/documentation/overview/mixins/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.0/documentation/overview/modular/index.html
+++ b/0.5.0/documentation/overview/modular/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.0/documentation/overview/responsiveness/index.html
+++ b/0.5.0/documentation/overview/responsiveness/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.0/documentation/overview/start/index.html
+++ b/0.5.0/documentation/overview/start/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.0/documentation/overview/variables/index.html
+++ b/0.5.0/documentation/overview/variables/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.0/extensions/index.html
+++ b/0.5.0/extensions/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.0/index.html
+++ b/0.5.0/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.1/2016/02/09/blog-launched-new-responsive-columns-new-helpers/index.html
+++ b/0.5.1/2016/02/09/blog-launched-new-responsive-columns-new-helpers/index.html
@@ -114,7 +114,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.1/2016/04/11/metro-ui-css-grid-with-bulma-tiles/index.html
+++ b/0.5.1/2016/04/11/metro-ui-css-grid-with-bulma-tiles/index.html
@@ -114,7 +114,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.1/2017/03/10/new-field-element/index.html
+++ b/0.5.1/2017/03/10/new-field-element/index.html
@@ -114,7 +114,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.1/2017/07/24/access-previous-bulma-versions/index.html
+++ b/0.5.1/2017/07/24/access-previous-bulma-versions/index.html
@@ -114,7 +114,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.1/2017/08/01/bulma-bootstrap-comparison/index.html
+++ b/0.5.1/2017/08/01/bulma-bootstrap-comparison/index.html
@@ -114,7 +114,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.1/2017/08/03/list-of-tags/index.html
+++ b/0.5.1/2017/08/03/list-of-tags/index.html
@@ -114,7 +114,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.1/alternative-to-bootstrap/index.html
+++ b/0.5.1/alternative-to-bootstrap/index.html
@@ -104,7 +104,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.1/blog/index.html
+++ b/0.5.1/blog/index.html
@@ -114,7 +114,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.1/documentation/components/breadcrumb/index.html
+++ b/0.5.1/documentation/components/breadcrumb/index.html
@@ -114,7 +114,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.1/documentation/components/card/index.html
+++ b/0.5.1/documentation/components/card/index.html
@@ -114,7 +114,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.1/documentation/components/dropdown/index.html
+++ b/0.5.1/documentation/components/dropdown/index.html
@@ -114,7 +114,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.1/documentation/components/level/index.html
+++ b/0.5.1/documentation/components/level/index.html
@@ -114,7 +114,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.1/documentation/components/media-object/index.html
+++ b/0.5.1/documentation/components/media-object/index.html
@@ -114,7 +114,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.1/documentation/components/menu/index.html
+++ b/0.5.1/documentation/components/menu/index.html
@@ -114,7 +114,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.1/documentation/components/message/index.html
+++ b/0.5.1/documentation/components/message/index.html
@@ -114,7 +114,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.1/documentation/components/modal/index.html
+++ b/0.5.1/documentation/components/modal/index.html
@@ -114,7 +114,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.1/documentation/components/nav/index.html
+++ b/0.5.1/documentation/components/nav/index.html
@@ -114,7 +114,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.1/documentation/components/navbar/index.html
+++ b/0.5.1/documentation/components/navbar/index.html
@@ -114,7 +114,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>
@@ -645,7 +645,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>
@@ -1437,7 +1437,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.1/documentation/components/pagination/index.html
+++ b/0.5.1/documentation/components/pagination/index.html
@@ -114,7 +114,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.1/documentation/components/panel/index.html
+++ b/0.5.1/documentation/components/panel/index.html
@@ -114,7 +114,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.1/documentation/components/tabs/index.html
+++ b/0.5.1/documentation/components/tabs/index.html
@@ -114,7 +114,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.1/documentation/elements/box/index.html
+++ b/0.5.1/documentation/elements/box/index.html
@@ -114,7 +114,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.1/documentation/elements/button/index.html
+++ b/0.5.1/documentation/elements/button/index.html
@@ -114,7 +114,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.1/documentation/elements/content/index.html
+++ b/0.5.1/documentation/elements/content/index.html
@@ -114,7 +114,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.1/documentation/elements/delete/index.html
+++ b/0.5.1/documentation/elements/delete/index.html
@@ -114,7 +114,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.1/documentation/elements/form/index.html
+++ b/0.5.1/documentation/elements/form/index.html
@@ -114,7 +114,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.1/documentation/elements/icon/index.html
+++ b/0.5.1/documentation/elements/icon/index.html
@@ -114,7 +114,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.1/documentation/elements/image/index.html
+++ b/0.5.1/documentation/elements/image/index.html
@@ -114,7 +114,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.1/documentation/elements/notification/index.html
+++ b/0.5.1/documentation/elements/notification/index.html
@@ -114,7 +114,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.1/documentation/elements/progress/index.html
+++ b/0.5.1/documentation/elements/progress/index.html
@@ -114,7 +114,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.1/documentation/elements/table/index.html
+++ b/0.5.1/documentation/elements/table/index.html
@@ -114,7 +114,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.1/documentation/elements/tag/index.html
+++ b/0.5.1/documentation/elements/tag/index.html
@@ -114,7 +114,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.1/documentation/elements/title/index.html
+++ b/0.5.1/documentation/elements/title/index.html
@@ -114,7 +114,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.1/documentation/form/checkbox/index.html
+++ b/0.5.1/documentation/form/checkbox/index.html
@@ -114,7 +114,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.1/documentation/form/file/index.html
+++ b/0.5.1/documentation/form/file/index.html
@@ -114,7 +114,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.1/documentation/form/general/index.html
+++ b/0.5.1/documentation/form/general/index.html
@@ -114,7 +114,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.1/documentation/form/input/index.html
+++ b/0.5.1/documentation/form/input/index.html
@@ -114,7 +114,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.1/documentation/form/radio/index.html
+++ b/0.5.1/documentation/form/radio/index.html
@@ -114,7 +114,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.1/documentation/form/select/index.html
+++ b/0.5.1/documentation/form/select/index.html
@@ -114,7 +114,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.1/documentation/form/textarea/index.html
+++ b/0.5.1/documentation/form/textarea/index.html
@@ -114,7 +114,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.1/documentation/grid/columns/index.html
+++ b/0.5.1/documentation/grid/columns/index.html
@@ -114,7 +114,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.1/documentation/grid/tiles/index.html
+++ b/0.5.1/documentation/grid/tiles/index.html
@@ -114,7 +114,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.1/documentation/layout/container/index.html
+++ b/0.5.1/documentation/layout/container/index.html
@@ -114,7 +114,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.1/documentation/layout/footer/index.html
+++ b/0.5.1/documentation/layout/footer/index.html
@@ -114,7 +114,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.1/documentation/layout/hero/index.html
+++ b/0.5.1/documentation/layout/hero/index.html
@@ -114,7 +114,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.1/documentation/layout/section/index.html
+++ b/0.5.1/documentation/layout/section/index.html
@@ -114,7 +114,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.1/documentation/modifiers/helpers/index.html
+++ b/0.5.1/documentation/modifiers/helpers/index.html
@@ -114,7 +114,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.1/documentation/modifiers/responsive-helpers/index.html
+++ b/0.5.1/documentation/modifiers/responsive-helpers/index.html
@@ -114,7 +114,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.1/documentation/modifiers/syntax/index.html
+++ b/0.5.1/documentation/modifiers/syntax/index.html
@@ -114,7 +114,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.1/documentation/modifiers/typography-helpers/index.html
+++ b/0.5.1/documentation/modifiers/typography-helpers/index.html
@@ -114,7 +114,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.1/documentation/overview/classes/index.html
+++ b/0.5.1/documentation/overview/classes/index.html
@@ -114,7 +114,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.1/documentation/overview/colors/index.html
+++ b/0.5.1/documentation/overview/colors/index.html
@@ -114,7 +114,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.1/documentation/overview/customize/index.html
+++ b/0.5.1/documentation/overview/customize/index.html
@@ -114,7 +114,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.1/documentation/overview/functions/index.html
+++ b/0.5.1/documentation/overview/functions/index.html
@@ -114,7 +114,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.1/documentation/overview/mixins/index.html
+++ b/0.5.1/documentation/overview/mixins/index.html
@@ -114,7 +114,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.1/documentation/overview/modular/index.html
+++ b/0.5.1/documentation/overview/modular/index.html
@@ -114,7 +114,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.1/documentation/overview/responsiveness/index.html
+++ b/0.5.1/documentation/overview/responsiveness/index.html
@@ -114,7 +114,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.1/documentation/overview/start/index.html
+++ b/0.5.1/documentation/overview/start/index.html
@@ -114,7 +114,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.1/documentation/overview/variables/index.html
+++ b/0.5.1/documentation/overview/variables/index.html
@@ -114,7 +114,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.1/expo/index.html
+++ b/0.5.1/expo/index.html
@@ -116,7 +116,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.1/extensions/index.html
+++ b/0.5.1/extensions/index.html
@@ -114,7 +114,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.1/index.html
+++ b/0.5.1/index.html
@@ -114,7 +114,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.1/love/index.html
+++ b/0.5.1/love/index.html
@@ -114,7 +114,7 @@
               </p>
 
                 <small>
-                  <a class="view-all-versions" href="/versions">View all versions</a>
+                  <a class="view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/2016/02/09/blog-launched-new-responsive-columns-new-helpers/index.html
+++ b/0.5.2/2016/02/09/blog-launched-new-responsive-columns-new-helpers/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/2016/04/11/metro-ui-css-grid-with-bulma-tiles/index.html
+++ b/0.5.2/2016/04/11/metro-ui-css-grid-with-bulma-tiles/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/2017/03/10/new-field-element/index.html
+++ b/0.5.2/2017/03/10/new-field-element/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/2017/07/24/access-previous-bulma-versions/index.html
+++ b/0.5.2/2017/07/24/access-previous-bulma-versions/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/2017/08/01/bulma-bootstrap-comparison/index.html
+++ b/0.5.2/2017/08/01/bulma-bootstrap-comparison/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/2017/08/03/list-of-tags/index.html
+++ b/0.5.2/2017/08/03/list-of-tags/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/alternative-to-bootstrap/index.html
+++ b/0.5.2/alternative-to-bootstrap/index.html
@@ -104,7 +104,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/blog/index.html
+++ b/0.5.2/blog/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/documentation/columns/basics/index.html
+++ b/0.5.2/documentation/columns/basics/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/documentation/columns/gap/index.html
+++ b/0.5.2/documentation/columns/gap/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/documentation/columns/nesting/index.html
+++ b/0.5.2/documentation/columns/nesting/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/documentation/columns/options/index.html
+++ b/0.5.2/documentation/columns/options/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/documentation/columns/responsiveness/index.html
+++ b/0.5.2/documentation/columns/responsiveness/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/documentation/columns/sizes/index.html
+++ b/0.5.2/documentation/columns/sizes/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/documentation/components/breadcrumb/index.html
+++ b/0.5.2/documentation/components/breadcrumb/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/documentation/components/card/index.html
+++ b/0.5.2/documentation/components/card/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/documentation/components/dropdown/index.html
+++ b/0.5.2/documentation/components/dropdown/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/documentation/components/level/index.html
+++ b/0.5.2/documentation/components/level/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/documentation/components/media-object/index.html
+++ b/0.5.2/documentation/components/media-object/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/documentation/components/menu/index.html
+++ b/0.5.2/documentation/components/menu/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/documentation/components/message/index.html
+++ b/0.5.2/documentation/components/message/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/documentation/components/modal/index.html
+++ b/0.5.2/documentation/components/modal/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/documentation/components/nav/index.html
+++ b/0.5.2/documentation/components/nav/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/documentation/components/navbar/index.html
+++ b/0.5.2/documentation/components/navbar/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>
@@ -1022,7 +1022,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/documentation/components/pagination/index.html
+++ b/0.5.2/documentation/components/pagination/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/documentation/components/panel/index.html
+++ b/0.5.2/documentation/components/panel/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/documentation/components/tabs/index.html
+++ b/0.5.2/documentation/components/tabs/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/documentation/elements/box/index.html
+++ b/0.5.2/documentation/elements/box/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/documentation/elements/button/index.html
+++ b/0.5.2/documentation/elements/button/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/documentation/elements/content/index.html
+++ b/0.5.2/documentation/elements/content/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/documentation/elements/delete/index.html
+++ b/0.5.2/documentation/elements/delete/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/documentation/elements/form/index.html
+++ b/0.5.2/documentation/elements/form/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/documentation/elements/icon/index.html
+++ b/0.5.2/documentation/elements/icon/index.html
@@ -123,7 +123,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/documentation/elements/image/index.html
+++ b/0.5.2/documentation/elements/image/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/documentation/elements/notification/index.html
+++ b/0.5.2/documentation/elements/notification/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/documentation/elements/progress/index.html
+++ b/0.5.2/documentation/elements/progress/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/documentation/elements/table/index.html
+++ b/0.5.2/documentation/elements/table/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/documentation/elements/tag/index.html
+++ b/0.5.2/documentation/elements/tag/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/documentation/elements/title/index.html
+++ b/0.5.2/documentation/elements/title/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/documentation/form/checkbox/index.html
+++ b/0.5.2/documentation/form/checkbox/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/documentation/form/file/index.html
+++ b/0.5.2/documentation/form/file/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/documentation/form/general/index.html
+++ b/0.5.2/documentation/form/general/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/documentation/form/input/index.html
+++ b/0.5.2/documentation/form/input/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/documentation/form/radio/index.html
+++ b/0.5.2/documentation/form/radio/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/documentation/form/select/index.html
+++ b/0.5.2/documentation/form/select/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/documentation/form/textarea/index.html
+++ b/0.5.2/documentation/form/textarea/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/documentation/grid/columns/index.html
+++ b/0.5.2/documentation/grid/columns/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/documentation/grid/tiles/index.html
+++ b/0.5.2/documentation/grid/tiles/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/documentation/layout/container/index.html
+++ b/0.5.2/documentation/layout/container/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/documentation/layout/footer/index.html
+++ b/0.5.2/documentation/layout/footer/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/documentation/layout/hero/index.html
+++ b/0.5.2/documentation/layout/hero/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/documentation/layout/level/index.html
+++ b/0.5.2/documentation/layout/level/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/documentation/layout/media-object/index.html
+++ b/0.5.2/documentation/layout/media-object/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/documentation/layout/section/index.html
+++ b/0.5.2/documentation/layout/section/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/documentation/layout/tiles/index.html
+++ b/0.5.2/documentation/layout/tiles/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/documentation/modifiers/helpers/index.html
+++ b/0.5.2/documentation/modifiers/helpers/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/documentation/modifiers/responsive-helpers/index.html
+++ b/0.5.2/documentation/modifiers/responsive-helpers/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/documentation/modifiers/syntax/index.html
+++ b/0.5.2/documentation/modifiers/syntax/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/documentation/modifiers/typography-helpers/index.html
+++ b/0.5.2/documentation/modifiers/typography-helpers/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/documentation/overview/classes/index.html
+++ b/0.5.2/documentation/overview/classes/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/documentation/overview/colors/index.html
+++ b/0.5.2/documentation/overview/colors/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/documentation/overview/customize/index.html
+++ b/0.5.2/documentation/overview/customize/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/documentation/overview/functions/index.html
+++ b/0.5.2/documentation/overview/functions/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/documentation/overview/mixins/index.html
+++ b/0.5.2/documentation/overview/mixins/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/documentation/overview/modular/index.html
+++ b/0.5.2/documentation/overview/modular/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/documentation/overview/responsiveness/index.html
+++ b/0.5.2/documentation/overview/responsiveness/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/documentation/overview/start/index.html
+++ b/0.5.2/documentation/overview/start/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/documentation/overview/variables/index.html
+++ b/0.5.2/documentation/overview/variables/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/expo/index.html
+++ b/0.5.2/expo/index.html
@@ -119,7 +119,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/extensions/index.html
+++ b/0.5.2/extensions/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/index.html
+++ b/0.5.2/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.2/love/index.html
+++ b/0.5.2/love/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/2016/02/09/blog-launched-new-responsive-columns-new-helpers/index.html
+++ b/0.5.3/2016/02/09/blog-launched-new-responsive-columns-new-helpers/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/2016/04/11/metro-ui-css-grid-with-bulma-tiles/index.html
+++ b/0.5.3/2016/04/11/metro-ui-css-grid-with-bulma-tiles/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/2017/03/10/new-field-element/index.html
+++ b/0.5.3/2017/03/10/new-field-element/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/2017/07/24/access-previous-bulma-versions/index.html
+++ b/0.5.3/2017/07/24/access-previous-bulma-versions/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/2017/08/01/bulma-bootstrap-comparison/index.html
+++ b/0.5.3/2017/08/01/bulma-bootstrap-comparison/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/2017/08/03/list-of-tags/index.html
+++ b/0.5.3/2017/08/03/list-of-tags/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/alternative-to-bootstrap/index.html
+++ b/0.5.3/alternative-to-bootstrap/index.html
@@ -104,7 +104,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/blog/index.html
+++ b/0.5.3/blog/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/documentation/columns/basics/index.html
+++ b/0.5.3/documentation/columns/basics/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/documentation/columns/gap/index.html
+++ b/0.5.3/documentation/columns/gap/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/documentation/columns/nesting/index.html
+++ b/0.5.3/documentation/columns/nesting/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/documentation/columns/options/index.html
+++ b/0.5.3/documentation/columns/options/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/documentation/columns/responsiveness/index.html
+++ b/0.5.3/documentation/columns/responsiveness/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/documentation/columns/sizes/index.html
+++ b/0.5.3/documentation/columns/sizes/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/documentation/components/breadcrumb/index.html
+++ b/0.5.3/documentation/components/breadcrumb/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/documentation/components/card/index.html
+++ b/0.5.3/documentation/components/card/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/documentation/components/dropdown/index.html
+++ b/0.5.3/documentation/components/dropdown/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/documentation/components/level/index.html
+++ b/0.5.3/documentation/components/level/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/documentation/components/media-object/index.html
+++ b/0.5.3/documentation/components/media-object/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/documentation/components/menu/index.html
+++ b/0.5.3/documentation/components/menu/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/documentation/components/message/index.html
+++ b/0.5.3/documentation/components/message/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/documentation/components/modal/index.html
+++ b/0.5.3/documentation/components/modal/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/documentation/components/nav/index.html
+++ b/0.5.3/documentation/components/nav/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/documentation/components/navbar/index.html
+++ b/0.5.3/documentation/components/navbar/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>
@@ -1022,7 +1022,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/documentation/components/pagination/index.html
+++ b/0.5.3/documentation/components/pagination/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/documentation/components/panel/index.html
+++ b/0.5.3/documentation/components/panel/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/documentation/components/tabs/index.html
+++ b/0.5.3/documentation/components/tabs/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/documentation/elements/box/index.html
+++ b/0.5.3/documentation/elements/box/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/documentation/elements/button/index.html
+++ b/0.5.3/documentation/elements/button/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/documentation/elements/content/index.html
+++ b/0.5.3/documentation/elements/content/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/documentation/elements/delete/index.html
+++ b/0.5.3/documentation/elements/delete/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/documentation/elements/form/index.html
+++ b/0.5.3/documentation/elements/form/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/documentation/elements/icon/index.html
+++ b/0.5.3/documentation/elements/icon/index.html
@@ -123,7 +123,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/documentation/elements/image/index.html
+++ b/0.5.3/documentation/elements/image/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/documentation/elements/notification/index.html
+++ b/0.5.3/documentation/elements/notification/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/documentation/elements/progress/index.html
+++ b/0.5.3/documentation/elements/progress/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/documentation/elements/table/index.html
+++ b/0.5.3/documentation/elements/table/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/documentation/elements/tag/index.html
+++ b/0.5.3/documentation/elements/tag/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/documentation/elements/title/index.html
+++ b/0.5.3/documentation/elements/title/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/documentation/form/checkbox/index.html
+++ b/0.5.3/documentation/form/checkbox/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/documentation/form/file/index.html
+++ b/0.5.3/documentation/form/file/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/documentation/form/general/index.html
+++ b/0.5.3/documentation/form/general/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/documentation/form/input/index.html
+++ b/0.5.3/documentation/form/input/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/documentation/form/radio/index.html
+++ b/0.5.3/documentation/form/radio/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/documentation/form/select/index.html
+++ b/0.5.3/documentation/form/select/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/documentation/form/textarea/index.html
+++ b/0.5.3/documentation/form/textarea/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/documentation/grid/columns/index.html
+++ b/0.5.3/documentation/grid/columns/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/documentation/grid/tiles/index.html
+++ b/0.5.3/documentation/grid/tiles/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/documentation/layout/container/index.html
+++ b/0.5.3/documentation/layout/container/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/documentation/layout/footer/index.html
+++ b/0.5.3/documentation/layout/footer/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/documentation/layout/hero/index.html
+++ b/0.5.3/documentation/layout/hero/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/documentation/layout/level/index.html
+++ b/0.5.3/documentation/layout/level/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/documentation/layout/media-object/index.html
+++ b/0.5.3/documentation/layout/media-object/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/documentation/layout/section/index.html
+++ b/0.5.3/documentation/layout/section/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/documentation/layout/tiles/index.html
+++ b/0.5.3/documentation/layout/tiles/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/documentation/modifiers/helpers/index.html
+++ b/0.5.3/documentation/modifiers/helpers/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/documentation/modifiers/responsive-helpers/index.html
+++ b/0.5.3/documentation/modifiers/responsive-helpers/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/documentation/modifiers/syntax/index.html
+++ b/0.5.3/documentation/modifiers/syntax/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/documentation/modifiers/typography-helpers/index.html
+++ b/0.5.3/documentation/modifiers/typography-helpers/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/documentation/overview/classes/index.html
+++ b/0.5.3/documentation/overview/classes/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/documentation/overview/colors/index.html
+++ b/0.5.3/documentation/overview/colors/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/documentation/overview/customize/index.html
+++ b/0.5.3/documentation/overview/customize/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/documentation/overview/functions/index.html
+++ b/0.5.3/documentation/overview/functions/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/documentation/overview/mixins/index.html
+++ b/0.5.3/documentation/overview/mixins/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/documentation/overview/modular/index.html
+++ b/0.5.3/documentation/overview/modular/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/documentation/overview/responsiveness/index.html
+++ b/0.5.3/documentation/overview/responsiveness/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/documentation/overview/start/index.html
+++ b/0.5.3/documentation/overview/start/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/documentation/overview/variables/index.html
+++ b/0.5.3/documentation/overview/variables/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/expo/index.html
+++ b/0.5.3/expo/index.html
@@ -119,7 +119,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/extensions/index.html
+++ b/0.5.3/extensions/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/index.html
+++ b/0.5.3/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.5.3/love/index.html
+++ b/0.5.3/love/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/2016/02/09/blog-launched-new-responsive-columns-new-helpers/index.html
+++ b/0.6.0/2016/02/09/blog-launched-new-responsive-columns-new-helpers/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/2016/04/11/metro-ui-css-grid-with-bulma-tiles/index.html
+++ b/0.6.0/2016/04/11/metro-ui-css-grid-with-bulma-tiles/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/2017/03/10/new-field-element/index.html
+++ b/0.6.0/2017/03/10/new-field-element/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/2017/07/24/access-previous-bulma-versions/index.html
+++ b/0.6.0/2017/07/24/access-previous-bulma-versions/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/2017/08/01/bulma-bootstrap-comparison/index.html
+++ b/0.6.0/2017/08/01/bulma-bootstrap-comparison/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/2017/08/03/list-of-tags/index.html
+++ b/0.6.0/2017/08/03/list-of-tags/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/2017/10/09/roses-are-red-links-are-blue/index.html
+++ b/0.6.0/2017/10/09/roses-are-red-links-are-blue/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/alternative-to-bootstrap/index.html
+++ b/0.6.0/alternative-to-bootstrap/index.html
@@ -104,7 +104,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/blog/index.html
+++ b/0.6.0/blog/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/documentation/columns/basics/index.html
+++ b/0.6.0/documentation/columns/basics/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/documentation/columns/gap/index.html
+++ b/0.6.0/documentation/columns/gap/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/documentation/columns/nesting/index.html
+++ b/0.6.0/documentation/columns/nesting/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/documentation/columns/options/index.html
+++ b/0.6.0/documentation/columns/options/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/documentation/columns/responsiveness/index.html
+++ b/0.6.0/documentation/columns/responsiveness/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/documentation/columns/sizes/index.html
+++ b/0.6.0/documentation/columns/sizes/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/documentation/components/breadcrumb/index.html
+++ b/0.6.0/documentation/components/breadcrumb/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/documentation/components/card/index.html
+++ b/0.6.0/documentation/components/card/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/documentation/components/dropdown/index.html
+++ b/0.6.0/documentation/components/dropdown/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/documentation/components/level/index.html
+++ b/0.6.0/documentation/components/level/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/documentation/components/media-object/index.html
+++ b/0.6.0/documentation/components/media-object/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/documentation/components/menu/index.html
+++ b/0.6.0/documentation/components/menu/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/documentation/components/message/index.html
+++ b/0.6.0/documentation/components/message/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/documentation/components/modal/index.html
+++ b/0.6.0/documentation/components/modal/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/documentation/components/nav/index.html
+++ b/0.6.0/documentation/components/nav/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/documentation/components/navbar/index.html
+++ b/0.6.0/documentation/components/navbar/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>
@@ -1029,7 +1029,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/documentation/components/pagination/index.html
+++ b/0.6.0/documentation/components/pagination/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/documentation/components/panel/index.html
+++ b/0.6.0/documentation/components/panel/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/documentation/components/tabs/index.html
+++ b/0.6.0/documentation/components/tabs/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/documentation/elements/box/index.html
+++ b/0.6.0/documentation/elements/box/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/documentation/elements/button/index.html
+++ b/0.6.0/documentation/elements/button/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/documentation/elements/content/index.html
+++ b/0.6.0/documentation/elements/content/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/documentation/elements/delete/index.html
+++ b/0.6.0/documentation/elements/delete/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/documentation/elements/form/index.html
+++ b/0.6.0/documentation/elements/form/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/documentation/elements/icon/index.html
+++ b/0.6.0/documentation/elements/icon/index.html
@@ -123,7 +123,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/documentation/elements/image/index.html
+++ b/0.6.0/documentation/elements/image/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/documentation/elements/notification/index.html
+++ b/0.6.0/documentation/elements/notification/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/documentation/elements/progress/index.html
+++ b/0.6.0/documentation/elements/progress/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/documentation/elements/table/index.html
+++ b/0.6.0/documentation/elements/table/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/documentation/elements/tag/index.html
+++ b/0.6.0/documentation/elements/tag/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/documentation/elements/title/index.html
+++ b/0.6.0/documentation/elements/title/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/documentation/form/checkbox/index.html
+++ b/0.6.0/documentation/form/checkbox/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/documentation/form/file/index.html
+++ b/0.6.0/documentation/form/file/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/documentation/form/general/index.html
+++ b/0.6.0/documentation/form/general/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/documentation/form/input/index.html
+++ b/0.6.0/documentation/form/input/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/documentation/form/radio/index.html
+++ b/0.6.0/documentation/form/radio/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/documentation/form/select/index.html
+++ b/0.6.0/documentation/form/select/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/documentation/form/textarea/index.html
+++ b/0.6.0/documentation/form/textarea/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/documentation/grid/columns/index.html
+++ b/0.6.0/documentation/grid/columns/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/documentation/grid/tiles/index.html
+++ b/0.6.0/documentation/grid/tiles/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/documentation/layout/container/index.html
+++ b/0.6.0/documentation/layout/container/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/documentation/layout/footer/index.html
+++ b/0.6.0/documentation/layout/footer/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/documentation/layout/hero/index.html
+++ b/0.6.0/documentation/layout/hero/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/documentation/layout/level/index.html
+++ b/0.6.0/documentation/layout/level/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/documentation/layout/media-object/index.html
+++ b/0.6.0/documentation/layout/media-object/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/documentation/layout/section/index.html
+++ b/0.6.0/documentation/layout/section/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/documentation/layout/tiles/index.html
+++ b/0.6.0/documentation/layout/tiles/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/documentation/modifiers/helpers/index.html
+++ b/0.6.0/documentation/modifiers/helpers/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/documentation/modifiers/responsive-helpers/index.html
+++ b/0.6.0/documentation/modifiers/responsive-helpers/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/documentation/modifiers/syntax/index.html
+++ b/0.6.0/documentation/modifiers/syntax/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/documentation/modifiers/typography-helpers/index.html
+++ b/0.6.0/documentation/modifiers/typography-helpers/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/documentation/overview/classes/index.html
+++ b/0.6.0/documentation/overview/classes/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/documentation/overview/colors/index.html
+++ b/0.6.0/documentation/overview/colors/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/documentation/overview/customize/index.html
+++ b/0.6.0/documentation/overview/customize/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/documentation/overview/functions/index.html
+++ b/0.6.0/documentation/overview/functions/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/documentation/overview/mixins/index.html
+++ b/0.6.0/documentation/overview/mixins/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/documentation/overview/modular/index.html
+++ b/0.6.0/documentation/overview/modular/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/documentation/overview/responsiveness/index.html
+++ b/0.6.0/documentation/overview/responsiveness/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/documentation/overview/start/index.html
+++ b/0.6.0/documentation/overview/start/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/documentation/overview/variables/index.html
+++ b/0.6.0/documentation/overview/variables/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/expo/index.html
+++ b/0.6.0/expo/index.html
@@ -119,7 +119,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/extensions/index.html
+++ b/0.6.0/extensions/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/index.html
+++ b/0.6.0/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>

--- a/0.6.0/love/index.html
+++ b/0.6.0/love/index.html
@@ -117,7 +117,7 @@
               </p>
 
                 <small>
-                  <a class="bd-view-all-versions" href="/versions">View all versions</a>
+                  <a class="bd-view-all-versions" href="https://versions.bulma.io">View all versions</a>
                 </small>
 
             </div>


### PR DESCRIPTION
@jgthms I finally managed to create the PR :tada: 

I changed all relative links that pointed to `/versions` and resulted in 404s.
The new target is `https://versions.bulma.io`.

resolves #1 